### PR TITLE
Security update and deprecation resolve

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(
     install_requires=[
         'bs4==0.0.1',
         'urllib3==1.23',
-        'requests==2.19.1',
+        'requests==2.20.0',
     ],
 )

--- a/tests/test_file_path.py
+++ b/tests/test_file_path.py
@@ -16,16 +16,16 @@ class TestPathValidation(TestCase):
         with self.assertRaises(ValueError) as context:
             self.request_obj._validate_path('test_url', self.filename)
 
-        self.assertEquals('Need full path. Provided path - {}'.format(self.filename), str(context.exception))
+        self.assertEqual('Need full path. Provided path - {}'.format(self.filename), str(context.exception))
 
     def test_valid_full_path(self):
         path = os.path.join(os.path.abspath(__file__), self.filename)
         returned_path = self.request_obj._validate_path('test_url', path)
-        self.assertEquals(returned_path, path)
+        self.assertEqual(returned_path, path)
 
     def test_dir_does_not_exist(self):
         path = os.path.join(os.path.join(os.path.abspath(__file__), 'dir-which-does-not-exist'), self.filename)
         with self.assertRaises(ValueError) as context:
             self.request_obj._validate_path('test_url', path)
 
-        self.assertEquals('Directory does not exist at {}'.format(path), str(context.exception))
+        self.assertEqual('Directory does not exist at {}'.format(path), str(context.exception))

--- a/tests/test_form_request_type.py
+++ b/tests/test_form_request_type.py
@@ -13,14 +13,14 @@ class TestRequestTypeForming(TestCase):
     def test_accept_type_simple_case(self):
         accept_type = 'json'
         expected_result = 'application/json'
-        self.assertEquals(self.request_obj._form_request_accept_type(accept_type), expected_result)
+        self.assertEqual(self.request_obj._form_request_accept_type(accept_type), expected_result)
 
     def test_no_accept_type(self):
         accept_type = None
         expected_result = '*/*'
-        self.assertEquals(self.request_obj._form_request_accept_type(accept_type), expected_result)
+        self.assertEqual(self.request_obj._form_request_accept_type(accept_type), expected_result)
 
     def test_full_accept_type(self):
         accept_type = 'application/xml'
         expected_result = 'application/xml'
-        self.assertEquals(self.request_obj._form_request_accept_type(accept_type), expected_result)
+        self.assertEqual(self.request_obj._form_request_accept_type(accept_type), expected_result)

--- a/tests/test_missing_class_variables.py
+++ b/tests/test_missing_class_variables.py
@@ -13,7 +13,7 @@ class TestMissingClassVariables(TestCase):
         with self.assertRaises(MissingVariables) as context:
             check_needed_class_vars(reso, [variable])
 
-        self.assertEquals('Missing {} on {}'.format(variable, reso.__class__.__name__), str(context.exception))
+        self.assertEqual('Missing {} on {}'.format(variable, reso.__class__.__name__), str(context.exception))
 
     def test_validate_no_missing_variable(self):
         reso = RESO(client_id='some-client-id')

--- a/tests/test_open_id_init.py
+++ b/tests/test_open_id_init.py
@@ -9,4 +9,4 @@ class TestOpenID(TestCase):
         with self.assertRaises(ValueError) as context:
             OpenIDAuthentication(reso='reso')
 
-        self.assertEquals('Must be of type RESO', str(context.exception))
+        self.assertEqual('Must be of type RESO', str(context.exception))

--- a/tests/test_return_formed_url.py
+++ b/tests/test_return_formed_url.py
@@ -11,7 +11,7 @@ class TestUrlsForming(TestCase):
         expected_result = backslash_url + path
         reso = RESO(api_request_url=backslash_url)
         request_obj = HttpRequest(reso)
-        self.assertEquals(request_obj._return_formed_url(path), expected_result)
+        self.assertEqual(request_obj._return_formed_url(path), expected_result)
 
     def test_api_request_both_urls_have_backslashes(self):
         backslash_url = 'http://example.com/'
@@ -19,7 +19,7 @@ class TestUrlsForming(TestCase):
         expected_result = backslash_url[:-1] + path
         reso = RESO(api_request_url=backslash_url)
         request_obj = HttpRequest(reso)
-        self.assertEquals(request_obj._return_formed_url(path), expected_result)
+        self.assertEqual(request_obj._return_formed_url(path), expected_result)
 
     def test_api_request_both_urls_without_backslashes(self):
         backslash_url = 'http://example.com'
@@ -27,7 +27,7 @@ class TestUrlsForming(TestCase):
         expected_result = backslash_url + '/' + path
         reso = RESO(api_request_url=backslash_url)
         request_obj = HttpRequest(reso)
-        self.assertEquals(request_obj._return_formed_url(path), expected_result)
+        self.assertEqual(request_obj._return_formed_url(path), expected_result)
 
     def test_api_request_url_endswith_without_backslash(self):
         backslash_url = 'http://example.com'
@@ -35,4 +35,4 @@ class TestUrlsForming(TestCase):
         expected_result = backslash_url + path
         reso = RESO(api_request_url=backslash_url)
         request_obj = HttpRequest(reso)
-        self.assertEquals(request_obj._return_formed_url(path), expected_result)
+        self.assertEqual(request_obj._return_formed_url(path), expected_result)


### PR DESCRIPTION
### Description of the Change

Security update for `requests` library while updating it up to 2.20.0. Also, updated tests to use `assertEqual` instead of `assertEquals` because of the upcoming deprecation. This will resolve the #5 issue

### Benefits

No more security vulnerability alerts will be thrown and API will be more secured. 

### Possible Drawbacks

Should be none, but it might come up because of the bugs in library. 

### Verification Process

Tests were executed.

### Applicable Issues

None